### PR TITLE
Fix Spine visibility when pawns are carried or stored

### DIFF
--- a/DynamicObject/DynamicObjectInstance.cs
+++ b/DynamicObject/DynamicObjectInstance.cs
@@ -417,9 +417,43 @@ namespace RimSpine2DFramework
 
             Map pawnMap = curPawn.MapHeld;
 
-            if (pawnMap == null || currentMap == null)
+            if (currentMap == null)
             {
-                return true;
+                return false;
+            }
+
+            if (pawnMap == null)
+            {
+                if (TryGetHeldThingDrawInfo(curPawn, out _, out Map holderMap))
+                {
+                    pawnMap = holderMap;
+                }
+                else
+                {
+                    IThingHolder holder = GetEffectiveRenderHolder(curPawn);
+
+                    if (holder == null)
+                    {
+                        return false;
+                    }
+
+                    if (holder is Pawn_CarryTracker && !VisibleWhileCarried)
+                    {
+                        return false;
+                    }
+
+                    if (IsStoredInHolder(holder) && !VisibleWhileStored)
+                    {
+                        return false;
+                    }
+
+                    pawnMap = GetThingHolderMap(holder);
+                }
+            }
+
+            if (pawnMap == null)
+            {
+                return false;
             }
 
             return pawnMap == currentMap;


### PR DESCRIPTION
## Summary
- ensure dynamic objects only render when their pawn or corpse has a visible holder map
- respect visibility toggles for carried or stored pawns before rendering when off-map

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0cb392e6c83258219ae91411b9225