### PR TITLE
Support assigning ThinkNode_Subtree tree defs without XML loader

### DIFF
--- a/DynamicObject/HumanlikeThinkTreeLibrary.cs
+++ b/DynamicObject/HumanlikeThinkTreeLibrary.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.Security.Cryptography;
+using System.Reflection;
 using System.Xml;
 using RimWorld;
 using Verse;
+using Verse.AI;
 
 namespace RimSpine2DFramework
 {
@@ -491,7 +492,7 @@ namespace RimSpine2DFramework
             foreach (XmlNode node in root.ChildNodes)
             {
                 XmlElement element = node as XmlElement;
-                if (node == null || element.Name != "ThinkTreeDef")
+                if (element == null || element.Name != "ThinkTreeDef")
                 {
                     continue;
                 }
@@ -503,6 +504,7 @@ namespace RimSpine2DFramework
                     def.fileName = "EmbeddedHumanlikeThinkTrees";
                     def.modContentPack = ModStaticMethod.ThisMod?.Content;
                     def.PostLoad();
+                    ManualResolveSubtrees(def.thinkRoot, element["thinkRoot"], def.defName);
                     def.ResolveReferences();
 
                     ModDynamicObjectManager.tmpThinkTreeDatabase[def.defName] = def;
@@ -516,5 +518,99 @@ namespace RimSpine2DFramework
 
         public static bool TryGetHumanlikeThinkTree(string defName, out ThinkTreeDef def) =>
             ModDynamicObjectManager.tmpThinkTreeDatabase.TryGetValue(defName, out def);
+
+        private static readonly Action<ThinkNode_Subtree, ThinkTreeDef>? TreeDefAssigner = CreateTreeDefAssigner();
+        private static bool treeDefAssignerWarned;
+
+        private static void ManualResolveSubtrees(ThinkNode node, XmlElement xmlElement, string owningDefName)
+        {
+            if (node == null || xmlElement == null)
+            {
+                return;
+            }
+
+            if (node is ThinkNode_Subtree subtree)
+            {
+                var treeDefElement = xmlElement["treeDef"];
+                if (treeDefElement != null)
+                {
+                    var referencedName = treeDefElement.InnerText.Trim();
+                    if (!referencedName.NullOrEmpty())
+                    {
+                        var referencedDef = DefDatabase<ThinkTreeDef>.GetNamedSilentFail(referencedName);
+                        if (referencedDef == null)
+                        {
+                            ModDynamicObjectManager.tmpThinkTreeDatabase.TryGetValue(referencedName, out referencedDef);
+                        }
+
+                        if (referencedDef != null)
+                        {
+                            if (TreeDefAssigner != null)
+                            {
+                                TreeDefAssigner(subtree, referencedDef);
+                            }
+                            else if (!treeDefAssignerWarned)
+                            {
+                                treeDefAssignerWarned = true;
+                                Log.Warning($"[RimSpine2DFramework] Unable to assign treeDef for ThinkNode_Subtree when building '{owningDefName}'.");
+                            }
+                        }
+                        else
+                        {
+                            Log.Warning($"[RimSpine2DFramework] Failed to resolve ThinkTreeDef '{referencedName}' for embedded think tree '{owningDefName}'.");
+                        }
+                    }
+                }
+            }
+
+            if (node.subNodes == null || node.subNodes.Count == 0)
+            {
+                return;
+            }
+
+            var xmlSubNodes = xmlElement["subNodes"];
+            if (xmlSubNodes == null)
+            {
+                return;
+            }
+
+            int index = 0;
+            foreach (XmlNode child in xmlSubNodes.ChildNodes)
+            {
+                if (child is not XmlElement childElement || childElement.Name != "li")
+                {
+                    continue;
+                }
+
+                if (index >= node.subNodes.Count)
+                {
+                    break;
+                }
+
+                ManualResolveSubtrees(node.subNodes[index], childElement, owningDefName);
+                index++;
+            }
+        }
+
+        private static Action<ThinkNode_Subtree, ThinkTreeDef>? CreateTreeDefAssigner()
+        {
+            var subtreeType = typeof(ThinkNode_Subtree);
+
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+            var property = subtreeType.GetProperty("treeDef", flags);
+            if (property?.GetSetMethod(true) is MethodInfo setter)
+            {
+                return (subtree, def) => setter.Invoke(subtree, new object[] { def });
+            }
+
+            var field = subtreeType.GetField("treeDef", flags) ?? subtreeType.GetField("treeDefInt", flags);
+            if (field != null)
+            {
+                return (subtree, def) => field.SetValue(subtree, def);
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- detect ThinkNode_Subtree instances when wiring embedded think trees
- assign their private treeDef property/field via reflection so ResolveReferences succeeds
- warn once if no backing member can be located

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d74243c88325afe73b2ab27f55ff