### PR TITLE
Reload dynamic storyteller assets after language change

### DIFF
--- a/DynamicObject/HarmonyMain.cs
+++ b/DynamicObject/HarmonyMain.cs
@@ -36,7 +36,7 @@ namespace RimSpine2DFramework
 		}*/
 
 
-		[HarmonyPatch(typeof(StorytellerUI))]
+        [HarmonyPatch(typeof(StorytellerUI))]
         [HarmonyPatch("DrawStorytellerSelectionInterface")]
         public class DynamicStoryTellerPatch
         {
@@ -188,9 +188,39 @@ namespace RimSpine2DFramework
                                 else
                                 {
                                     Find.WindowStack.Add(new Dialog_AnomalySettings(difficultyValues));
-                                }
-                            }
-                        }
+        }
+
+        [HarmonyPatch]
+        public static class LanguageReloadPatch
+        {
+            private static readonly string[] TargetMethodNames = new[]
+            {
+                "SelectLanguage",
+                "SetActiveLanguage",
+                "TrySetActiveLanguage",
+                "TrySelectActiveLanguage"
+            };
+
+            static IEnumerable<MethodBase> TargetMethods()
+            {
+                Type languageDatabaseType = typeof(LanguageDatabase);
+                foreach (string methodName in TargetMethodNames)
+                {
+                    MethodInfo method = AccessTools.Method(languageDatabaseType, methodName);
+                    if (method != null)
+                    {
+                        yield return method;
+                    }
+                }
+            }
+
+            static void Postfix()
+            {
+                ThisModBase.QueueReloadForLanguageChange();
+            }
+        }
+    }
+}
                     }
 					num = rect3.y + infoListing.CurHeight;
 					infoListing.End();

--- a/DynamicObject/ThisModBase.cs
+++ b/DynamicObject/ThisModBase.cs
@@ -41,6 +41,8 @@ namespace RimSpine2DFramework
         public Harmony harmonyInstance;
 
 
+        private static bool languageReloadScheduled;
+
         internal void LateInitialize()
         {
             try
@@ -51,6 +53,21 @@ namespace RimSpine2DFramework
             {
                 LogSimple.Message("An exception occurred during late initialization: " + e);
             }
+        }
+
+        internal static void QueueReloadForLanguageChange()
+        {
+            if (languageReloadScheduled)
+            {
+                return;
+            }
+
+            languageReloadScheduled = true;
+            LongEventHandler.ExecuteWhenFinished(() =>
+            {
+                languageReloadScheduled = false;
+                ForceReloadDynamicContent();
+            });
         }
 
         internal static void LoadInitialize()
@@ -67,6 +84,68 @@ namespace RimSpine2DFramework
                 ModStaticMethod.message = "loaded";
                 ModStaticMethod.AllLevelsLoaded = true;
                 //Log.Warning(ModStaticMethod.message);
+            }
+        }
+
+        private static void ForceReloadDynamicContent()
+        {
+            try
+            {
+                ModStaticMethod.AllLevelsLoaded = false;
+                ClearDynamicContentCaches();
+                LoadAndResolveAllDynamicDefs();
+                ResolveAllStoryTellerCameras();
+                ModStaticMethod.message = "loaded";
+            }
+            catch (Exception e)
+            {
+                LogSimple.Message("An exception occurred while reloading dynamic content: " + e);
+            }
+            finally
+            {
+                ModStaticMethod.AllLevelsLoaded = true;
+            }
+        }
+
+        private static void ClearDynamicContentCaches()
+        {
+            try
+            {
+                foreach (GameObject storytellerObject in ModDynamicObjectManager.DynamicStoryTellerDatabase.Values)
+                {
+                    if (storytellerObject == null)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        Camera camera = storytellerObject.GetComponent<Camera>();
+                        if (camera != null)
+                        {
+                            RenderTexture target = camera.targetTexture;
+                            camera.targetTexture = null;
+                            if (target != null)
+                            {
+                                target.Release();
+                                UnityEngine.Object.Destroy(target);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        UnityEngine.Object.Destroy(storytellerObject);
+                    }
+                }
+            }
+            finally
+            {
+                ModDynamicObjectManager.DynamicStoryTellerDatabase.Clear();
+                ModDynamicObjectManager.lastChosenStoryTeller = null;
+                ModDynamicObjectManager.spine35Database.Clear();
+                ModDynamicObjectManager.spine38Database.Clear();
+                ModDynamicObjectManager.spine40Database.Clear();
+                ModDynamicObjectManager.spine41Database.Clear();
             }
         }
 


### PR DESCRIPTION
## Summary
- queue a reload of RimSpine dynamic content whenever RimWorld finishes changing the active language
- clear cached storyteller cameras and Spine asset data before rebuilding them so textures are restored after the reload

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6902d116105483258ee47462d2f0f8bf