### PR TITLE
Add AlienRace compatibility for chibi body graphics

### DIFF
--- a/DynamicObject/Core/DynamicObjectInstance.cs
+++ b/DynamicObject/Core/DynamicObjectInstance.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using RimWorld;
 using RimWorld.Planet;
 using UnityEngine;
@@ -64,6 +65,8 @@ namespace RimSpine2DFramework
             { Tuple.Create(ImportMode.File, Spine41Adapter.Version), Spine41Adapter },
             { Tuple.Create(ImportMode.AssetBundle, Spine41Adapter.Version), Spine41Adapter }
         };
+
+        private static readonly FieldInfo ThingMapIndexOrStateField = typeof(Thing).GetField("mapIndexOrState", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public bool IsNull
         {
@@ -210,7 +213,12 @@ namespace RimSpine2DFramework
 
             if (!curPawn.DestroyedOrNull())
             {
-                bool shouldUseHeldThingDrawInfo = !curPawn.Spawned || IsHeldByNonMapParentHolder(curPawn);
+                if (!TryGetSpawnedState(curPawn, out bool pawnSpawned))
+                {
+                    return false;
+                }
+
+                bool shouldUseHeldThingDrawInfo = !pawnSpawned || IsHeldByNonMapParentHolder(curPawn);
 
                 if (shouldUseHeldThingDrawInfo)
                 {
@@ -230,6 +238,7 @@ namespace RimSpine2DFramework
                         Vector3 basePosition = curPawn.Position.ToVector3ShiftedWithAltitude(AltitudeLayer.Pawn);
                         drawPosition = new Vector3(basePosition.x, drawPosition.y, basePosition.z);
                     }
+
                     drawMap = curPawn.Map;
                 }
 
@@ -244,7 +253,12 @@ namespace RimSpine2DFramework
                 return false;
             }
 
-            if (corpse.Spawned)
+            if (!TryGetSpawnedState(corpse, out bool corpseSpawned))
+            {
+                return false;
+            }
+
+            if (corpseSpawned)
             {
                 drawPosition = corpse.DrawPos;
                 drawMap = corpse.Map;
@@ -514,6 +528,44 @@ namespace RimSpine2DFramework
             return false;
         }
 
+        private static bool TryGetSpawnedState(Thing thing, out bool spawned)
+        {
+            spawned = false;
+
+            if (thing == null)
+            {
+                return false;
+            }
+
+            if (ThingMapIndexOrStateField != null)
+            {
+                object rawValue = ThingMapIndexOrStateField.GetValue(thing);
+
+                if (rawValue is int mapIndexOrState)
+                {
+                    if (mapIndexOrState >= 0)
+                    {
+                        List<Map> maps = Find.Maps;
+                        int mapCount = maps?.Count ?? 0;
+
+                        if (mapIndexOrState < mapCount)
+                        {
+                            spawned = true;
+                            return true;
+                        }
+
+                        return false;
+                    }
+
+                    spawned = false;
+                    return true;
+                }
+            }
+
+            spawned = thing.Spawned;
+            return true;
+        }
+
         private static bool IsHeldByNonMapParentHolder(Thing thing)
         {
             if (thing == null)
@@ -554,8 +606,13 @@ namespace RimSpine2DFramework
 
                 if (carrier != null)
                 {
-                    holderMap = carrier.MapHeld;
-                    holderPosition = carrier.Spawned ? carrier.DrawPos : GetHeldThingFallbackPosition(thing);
+                    if (!TryGetSpawnedState(carrier, out bool carrierSpawned))
+                    {
+                        return false;
+                    }
+
+                    holderMap = carrierSpawned ? carrier.Map : GetThingHolderMap(holder);
+                    holderPosition = carrierSpawned ? carrier.DrawPos : GetHeldThingFallbackPosition(thing);
                 }
                 else
                 {
@@ -580,8 +637,13 @@ namespace RimSpine2DFramework
 
             if (holder is Thing holderThing)
             {
-                holderMap = holderThing.MapHeld;
-                holderPosition = holderThing.Spawned ? holderThing.DrawPos : GetHeldThingFallbackPosition(holderThing);
+                if (!TryGetSpawnedState(holderThing, out bool holderThingSpawned))
+                {
+                    return false;
+                }
+
+                holderMap = holderThingSpawned ? holderThing.Map : GetThingHolderMap(holder);
+                holderPosition = holderThingSpawned ? holderThing.DrawPos : GetHeldThingFallbackPosition(holderThing);
 
                 if (holderMap == null)
                 {
@@ -766,7 +828,17 @@ namespace RimSpine2DFramework
 
             if (holder is Thing holderThing)
             {
-                return holderThing.MapHeld ?? ThingOwnerUtility.GetRootMap(holder);
+                if (!TryGetSpawnedState(holderThing, out bool holderSpawned))
+                {
+                    return ThingOwnerUtility.GetRootMap(holder);
+                }
+
+                if (holderSpawned)
+                {
+                    return holderThing.Map;
+                }
+
+                return ThingOwnerUtility.GetRootMap(holder);
             }
 
             return ThingOwnerUtility.GetRootMap(holder);
@@ -786,7 +858,7 @@ namespace RimSpine2DFramework
                 return positionHeld.ToVector3Shifted();
             }
 
-            if (thing.Spawned)
+            if (TryGetSpawnedState(thing, out bool thingSpawned) && thingSpawned)
             {
                 return thing.DrawPos;
             }

--- a/DynamicObject/DynamicObject.csproj
+++ b/DynamicObject/DynamicObject.csproj
@@ -383,6 +383,7 @@
     <Compile Include="Pawn\StateMachine\DynamicPawnStateRegistry.cs" />
     <Compile Include="Pawn\StateMachine\DynamicPawnSelectionWrapper.cs" />
     <Compile Include="Definitions\DynamicStoryTellerDef.cs" />
+    <Compile Include="Harmony\AlienRaceBodyGraphicPatch.cs" />
     <Compile Include="Harmony\HarmonyMain.cs" />
     <Compile Include="Incidents\IncidentWorker_AggressiveOriginiumSlug.cs" />
     <Compile Include="Harmony\PawnStateHarmonyPatches.cs" />

--- a/DynamicObject/Harmony/AlienRaceBodyGraphicPatch.cs
+++ b/DynamicObject/Harmony/AlienRaceBodyGraphicPatch.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace RimSpine2DFramework
+{
+    [HarmonyPatch]
+    internal static class AlienRaceBodyGraphicPatch
+    {
+        private const string AlienRacePackageId = "erdelf.humanoidalienraces";
+
+        private static bool Prepare()
+        {
+            return ModsConfig.ActiveModsInLoadOrder.Any(mod => mod?.PackageIdPlayerFacing != null && mod.PackageIdLowerCase == AlienRacePackageId);
+        }
+
+        private static MethodBase TargetMethod()
+        {
+            Type patchType = AccessTools.TypeByName("AlienRace.AlienRenderTreePatches");
+            if (patchType == null)
+            {
+                return null;
+            }
+
+            return AccessTools.Method(patchType, "BodyGraphicForPrefix");
+        }
+
+        [HarmonyPriority(Priority.First)]
+        private static bool Prefix(object __instance, Pawn pawn, ref Graphic __result)
+        {
+            if (__instance is Chibi_PawnRenderNode_Body chibiNode && chibiNode.TryResolveChibiGraphic(pawn, out Graphic graphic))
+            {
+                __result = graphic;
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/DynamicObject/Pawn/Rendering/Chibi_PawnRenderNode_Body.cs
+++ b/DynamicObject/Pawn/Rendering/Chibi_PawnRenderNode_Body.cs
@@ -11,47 +11,61 @@ namespace RimSpine2DFramework
 {
     public class Chibi_PawnRenderNode_Body : PawnRenderNode_Body
     {
+        private readonly string initialTexPath;
+
         public Chibi_PawnRenderNode_Body(Pawn pawn, PawnRenderNodeProperties props, PawnRenderTree tree) : base(pawn, props, tree)
         {
-
+            initialTexPath = props?.texPath;
         }
 
         public override Graphic GraphicFor(Pawn pawn)
         {
-            if (props.texPath.NullOrEmpty())
+            if (TryResolveChibiGraphic(pawn, out Graphic graphic))
             {
-                return null;
+                return graphic;
             }
-            Shader shader = base.ShaderFor(pawn);
+
+            return base.GraphicFor(pawn);
+        }
+
+        internal bool TryResolveChibiGraphic(Pawn pawn, out Graphic graphic)
+        {
+            graphic = null;
+
+            if (pawn == null || props == null)
+            {
+                return false;
+            }
+
+            string texPath = initialTexPath ?? props.texPath;
+            if (texPath.NullOrEmpty())
+            {
+                return false;
+            }
+
+            // AlienRace 兼容：其前置补丁会把 texPath 改写为目录结构（例如 "Things/Pawn/Humanlike/Bodies/"）。
+            // 保留构造时的路径副本，遇到目录路径时回落到原始配置的贴图，避免错误地交给 Graphic_Multi。
+            if (texPath.EndsWith("/", StringComparison.Ordinal) || texPath.EndsWith("\\", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            Shader shader = ShaderFor(pawn);
             if (shader == null)
             {
-                return null;
+                return false;
             }
-            return GraphicDatabase.Get<Graphic_Single>(props.texPath, shader, Vector2.one, this.ColorFor(pawn));
-            /*if (pawn.story.bodyType == BodyTypeDefOf.Thin)
+
+            try
             {
-                pawn.story.bodyType = pawn.story.Childhood.bodyTypeFemale;
+                graphic = GraphicDatabase.Get<Graphic_Single>(texPath, shader, Vector2.one, ColorFor(pawn));
+                return graphic != null;
             }
-            if (pawn.Drawer.renderer.CurRotDrawMode == RotDrawMode.Dessicated)
+            catch (Exception ex)
             {
-                return GraphicDatabase.Get<Graphic_Single>(pawn.story.bodyType.bodyDessicatedGraphicPath, shader);
+                Log.ErrorOnce($"[RimSpine2DFramework] Failed to load chibi body graphic at '{texPath}': {ex}", texPath.GetHashCode() ^ GetHashCode());
+                return false;
             }
-            Pawn_StoryTracker story = pawn.story;
-            bool flag;
-            if (story == null)
-            {
-                flag = null != null;
-            }
-            else
-            {
-                BodyTypeDef bodyType = story.bodyType;
-                flag = ((bodyType != null) ? bodyType.bodyNakedGraphicPath : null) != null;
-            }
-            if (!flag)
-            {
-                return null;
-            }
-            return GraphicDatabase.Get<Graphic_Single>(pawn.story.bodyType.bodyNakedGraphicPath, shader, Vector2.one, this.ColorFor(pawn));*/
         }
     }
 }


### PR DESCRIPTION
## Summary
- cache the original chibi body texture path and reuse it when AlienRace rewrites the render node configuration
- add a Harmony prefix to short-circuit AlienRace's body graphic prefix for chibi nodes so the single-sprite path is used safely
- include the new compatibility patch file in the project build